### PR TITLE
feat: different fare for standalone and feeder drt

### DIFF
--- a/matsim-leeds/src/main/java/com/husseinmahfouz/matsim/dmc/mode_choice/LeedsModeChoiceModule.java
+++ b/matsim-leeds/src/main/java/com/husseinmahfouz/matsim/dmc/mode_choice/LeedsModeChoiceModule.java
@@ -15,7 +15,7 @@ import org.eqasim.core.simulation.modes.feeder_drt.mode_choice.FeederDrtModeAvai
 import org.eqasim.core.simulation.modes.feeder_drt.mode_choice.utilities.estimator.DefaultFeederDrtUtilityEstimator;
 import com.husseinmahfouz.matsim.dmc.mode_choice.costs.LeedsCarCostModel;
 import com.husseinmahfouz.matsim.dmc.mode_choice.costs.LeedsPtCostModel;
-import com.husseinmahfouz.matsim.dmc.mode_choice.costs.LeedsDrtCostModel;
+import com.husseinmahfouz.matsim.dmc.mode_choice.costs.LeedsDrtCostModelFeeder;
 import com.husseinmahfouz.matsim.dmc.mode_choice.costs.LeedsTaxiCostModel;
 import com.husseinmahfouz.matsim.dmc.mode_choice.parameters.LeedsCostParameters;
 import com.husseinmahfouz.matsim.dmc.mode_choice.parameters.LeedsModeParameters;
@@ -52,7 +52,7 @@ public class LeedsModeChoiceModule extends AbstractEqasimExtension {
 	public static final String CAR_COST_MODEL_NAME = "LeedsCarCostModel";
 	public static final String PT_COST_MODEL_NAME = "LeedsPtCostModel";
 	// Add DRT
-	public static final String DRT_COST_MODEL_NAME = "LeedsDrtCostModel";
+	public static final String DRT_COST_MODEL_NAME = "LeedsDrtCostModelFeeder";
 	public static final String TAXI_COST_MODEL_NAME = "LeedsTaxiCostModel";
 
 	public static final String CAR_ESTIMATOR_NAME = "LeedsCarUtilityEstimator";
@@ -79,7 +79,7 @@ public class LeedsModeChoiceModule extends AbstractEqasimExtension {
 		bindCostModel(CAR_COST_MODEL_NAME).to(LeedsCarCostModel.class);
 		bindCostModel(PT_COST_MODEL_NAME).to(LeedsPtCostModel.class);
 		// Add DRT
-		bindCostModel(DRT_COST_MODEL_NAME).to(LeedsDrtCostModel.class);
+		bindCostModel(DRT_COST_MODEL_NAME).to(LeedsDrtCostModelFeeder.class);
 		bindCostModel(TAXI_COST_MODEL_NAME).to(LeedsTaxiCostModel.class);
 
 		bindUtilityEstimator(CAR_ESTIMATOR_NAME).to(LeedsCarUtilityEstimator.class);

--- a/matsim-leeds/src/main/java/com/husseinmahfouz/matsim/dmc/mode_choice/costs/LeedsDrtCostModelFeeder.java
+++ b/matsim-leeds/src/main/java/com/husseinmahfouz/matsim/dmc/mode_choice/costs/LeedsDrtCostModelFeeder.java
@@ -73,6 +73,9 @@ public class LeedsDrtCostModelFeeder extends AbstractCostModel {
             // from the config to all individuals (regardless of drt service
             // area).So even though a person has these mode available, there is no feasible plan
             // with DRT. In that case, it is not an issue
+            // The serviceareaconstraint is applied right before the MNL (to eliminate modes), but the
+            // utility of each mode is calculated before the constraints are applied?
+
             // logger.warn("LeedsDrtCostModelFeeder received a trip with no DRT legs.");
             return 10000; // Return a high cost as this trip is not feasible with DRT (probably
             // unnecessary as it is excluded downstream, but we need a number)

--- a/matsim-leeds/src/main/java/com/husseinmahfouz/matsim/dmc/mode_choice/costs/LeedsDrtCostModelFeeder.java
+++ b/matsim-leeds/src/main/java/com/husseinmahfouz/matsim/dmc/mode_choice/costs/LeedsDrtCostModelFeeder.java
@@ -1,0 +1,77 @@
+package com.husseinmahfouz.matsim.dmc.mode_choice.costs;
+
+import java.util.List;
+
+// import org.apache.logging.log4j.LogManager;
+// import org.apache.logging.log4j.Logger;
+
+import org.eqasim.core.simulation.mode_choice.cost.AbstractCostModel;
+import com.husseinmahfouz.matsim.dmc.mode_choice.parameters.LeedsCostParameters;
+import org.matsim.api.core.v01.TransportMode;
+import org.matsim.api.core.v01.population.Leg;
+import org.matsim.api.core.v01.population.Person;
+import org.matsim.api.core.v01.population.PlanElement;
+import org.matsim.contribs.discrete_mode_choice.model.DiscreteModeChoiceTrip;
+
+import com.google.inject.Inject;
+
+/**
+ * This DRTCostModel is an alternative to the basic one. It incentivises using DRT as a feeder by
+ * making feeder trips free (similar to TfL hopper fare)
+ **/
+
+public class LeedsDrtCostModelFeeder extends AbstractCostModel {
+    // private static final Logger logger = LogManager.getLogger(LeedsDrtCostModelFeeder.class);
+    private final LeedsCostParameters costParameters;
+
+    @Inject
+    public LeedsDrtCostModelFeeder(LeedsCostParameters costParameters) {
+        super("drt");
+        this.costParameters = costParameters;
+    }
+
+    @Override
+    public double calculateCost_MU(Person person, DiscreteModeChoiceTrip trip,
+            List<? extends PlanElement> elements) {
+        boolean hasDrt = false;
+        boolean hasPt = false;
+
+        // Iterate through the plan elements to check for DRT and PT modes
+        // If both are present, this is a trip with a DRT feeder
+        for (PlanElement element : elements) {
+            if (element instanceof Leg) {
+                Leg leg = (Leg) element;
+                if (leg.getMode().equals(TransportMode.drt)) {
+                    hasDrt = true;
+                } else if (leg.getMode().equals(TransportMode.pt)) {
+                    hasPt = true;
+                }
+            }
+        }
+
+        // Calculate the cost based on the trip type (DRT only, or DRT as feeder to PT)
+        double tripDistance_km = getInVehicleDistance_km(elements);
+        if (hasDrt && hasPt) {
+            // DRT + PT trip (this is a trip with a DRT feeder)
+            // It is much cheaper (same as TfL hopper fare). Add 0.1 to avoid downstream issues
+            return (costParameters.drtFareBaseFeeder
+                    + costParameters.drtFarePerKmFeeder * tripDistance_km) + 0.1;
+        } else if (hasDrt) {
+            // DRT-only trip
+            return (costParameters.drtFareBase + costParameters.drtFarePerKm * tripDistance_km)
+                    + 0.1;
+        } else {
+            // If a trip has no DRT leg, the cost is set to a very high value
+            // TODO: figure out why these trips exist. I think it is because
+            // FeederDrtModeAvailabilityWrapper
+            // adds DRT and DRT_feeder modes from the config to all individuals (regardless of drt
+            // service
+            // area).So even though a person has these mode available, there is no feasible plan
+            // with DRT. In that case, it is not an issue
+            // logger.warn("LeedsDrtCostModelFeeder received a trip with no DRT legs.");
+            return 100; // Return a high cost as this trip is not feasible with DRT (probably
+                        // unnecessary as it is excluded downstream, but we need a number)
+        }
+        
+    }
+}

--- a/matsim-leeds/src/main/java/com/husseinmahfouz/matsim/dmc/mode_choice/costs/LeedsDrtCostModelFeeder.java
+++ b/matsim-leeds/src/main/java/com/husseinmahfouz/matsim/dmc/mode_choice/costs/LeedsDrtCostModelFeeder.java
@@ -40,12 +40,16 @@ public class LeedsDrtCostModelFeeder extends AbstractCostModel {
         for (PlanElement element : elements) {
             if (element instanceof Leg) {
                 Leg leg = (Leg) element;
-                String mode = leg.getMode();
+                // String mode = leg.getMode();
 
-                if (mode.contains("feeder")) {
+                // Check the routingMode attribute.
+                // This distinguishes between drt and drt_feeder modes
+                String routingMode = leg.getRoutingMode();
+
+                if (routingMode != null && routingMode.contains("feeder")) {
                     isFeederDrt = true;
                     break; // No need to check further if it's a feeder DRT trip
-                } else if (mode.contains("drt")) {
+                } else if (routingMode != null && routingMode.contains("drt")) {
                     isDrtOnly = true;
                 }
             }
@@ -70,7 +74,7 @@ public class LeedsDrtCostModelFeeder extends AbstractCostModel {
             // area).So even though a person has these mode available, there is no feasible plan
             // with DRT. In that case, it is not an issue
             // logger.warn("LeedsDrtCostModelFeeder received a trip with no DRT legs.");
-            return 100; // Return a high cost as this trip is not feasible with DRT (probably
+            return 10000; // Return a high cost as this trip is not feasible with DRT (probably
             // unnecessary as it is excluded downstream, but we need a number)
         }
     }

--- a/matsim-leeds/src/main/java/com/husseinmahfouz/matsim/dmc/mode_choice/parameters/LeedsCostParameters.java
+++ b/matsim-leeds/src/main/java/com/husseinmahfouz/matsim/dmc/mode_choice/parameters/LeedsCostParameters.java
@@ -12,6 +12,8 @@ public class LeedsCostParameters implements ParameterDefinition {
 	public double railFarePerKm;
 	public double drtFareBase;
 	public double drtFarePerKm;
+	public double drtFareBaseFeeder;
+	public double drtFarePerKmFeeder;
 
 	public static LeedsCostParameters buildDefault() {
 		LeedsCostParameters parameters = new LeedsCostParameters();
@@ -25,6 +27,9 @@ public class LeedsCostParameters implements ParameterDefinition {
 		// drt
 		parameters.drtFareBase = 2.0;
 		parameters.drtFarePerKm = 0.0;
+		// drt feeder: // to try scenarios where DRT is cheaper when used as a feeder
+		parameters.drtFareBaseFeeder = 0.5;
+		parameters.drtFarePerKmFeeder = 0.0;
 		// taxi
 		parameters.taxi_inititalCharge = 2.5;
 		parameters.taxiCostPerMinute = 0.2;

--- a/matsim-leeds/src/main/java/com/husseinmahfouz/matsim/dmc/mode_choice/parameters/LeedsCostParameters.java
+++ b/matsim-leeds/src/main/java/com/husseinmahfouz/matsim/dmc/mode_choice/parameters/LeedsCostParameters.java
@@ -18,7 +18,7 @@ public class LeedsCostParameters implements ParameterDefinition {
 	public static LeedsCostParameters buildDefault() {
 		LeedsCostParameters parameters = new LeedsCostParameters();
 		// car
-		parameters.carCostPerKm = 0.2;
+		parameters.carCostPerKm = 0.3;
 		// bus
 		parameters.busFare = 2.0;
 		parameters.railFareBase = 3.0;
@@ -28,7 +28,7 @@ public class LeedsCostParameters implements ParameterDefinition {
 		parameters.drtFareBase = 2.0;
 		parameters.drtFarePerKm = 0.0;
 		// drt feeder: // to try scenarios where DRT is cheaper when used as a feeder
-		parameters.drtFareBaseFeeder = 0.5;
+		parameters.drtFareBaseFeeder = 0.2;
 		parameters.drtFarePerKmFeeder = 0.0;
 		// taxi
 		parameters.taxi_inititalCharge = 2.5;


### PR DESCRIPTION
Attempt at trying to make DRT cost dependant on whether the DRT mode is used for the entire trip, or as a feeder to PT. The idea is to incentivise feeder services by making the fare cheaper than the standard DRT fare.

The `LeedsDrtCostModelFeeder` checks whether the trip uses `drt` mode or `drt_feeder` mode, and decides on the fare accordingly
